### PR TITLE
feat: Change Context configuration dynamically

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -89,7 +89,7 @@ const DefaultContext: ContextValue = {
 export class Context implements ContextValue {
   static PROVIDER = "refresh:provider";
 
-  private ctx: ContextValue;
+  private _ctx: ContextValue;
 
   /**
    * For internal events only.
@@ -97,9 +97,13 @@ export class Context implements ContextValue {
   events: EventEmitter;
 
   constructor(ctx: ContextValue) {
-    this.ctx = Object.assign({}, DefaultContext, ctx);
+    this._ctx = Object.assign({}, DefaultContext, ctx);
     this.events = new EventEmitter().setMaxListeners(100);
     this.setProvider(ctx.provider);
+  }
+
+  get ctx(): ContextValue {
+    return this._ctx;
   }
 
   /**

--- a/src/yearn.ts
+++ b/src/yearn.ts
@@ -51,7 +51,7 @@ type ServicesType<T extends ChainId> = {
   propertiesAggregator: PropertiesAggregatorService<T>;
 };
 
-type Config = { chainId: ChainId; context: Context; assetServiceState?: AssetServiceState };
+type Config = { chainId: ChainId; context: ContextValue; assetServiceState?: AssetServiceState };
 
 /**
  * [[Yearn]] is a wrapper for all the services and interfaces of the SDK.
@@ -154,7 +154,8 @@ export class Yearn<T extends ChainId> {
   }
 
   get config(): Config {
-    return { chainId: this.chainId, context: this.context, assetServiceState: this.assetServiceState };
+    const { ctx: contextValue } = this.context;
+    return { chainId: this.chainId, context: contextValue, assetServiceState: this.assetServiceState };
   }
 
   set config({ chainId, context, assetServiceState }: Config) {

--- a/src/yearn.ts
+++ b/src/yearn.ts
@@ -51,6 +51,8 @@ type ServicesType<T extends ChainId> = {
   propertiesAggregator: PropertiesAggregatorService<T>;
 };
 
+type Config = { chainId: ChainId; context: Context; assetServiceState?: AssetServiceState };
+
 /**
  * [[Yearn]] is a wrapper for all the services and interfaces of the SDK.
  *
@@ -151,19 +153,11 @@ export class Yearn<T extends ChainId> {
     this._assetServiceState = assetServiceState;
   }
 
-  get config(): { chainId: ChainId; context: Context; assetServiceState?: AssetServiceState } {
+  get config(): Config {
     return { chainId: this.chainId, context: this.context, assetServiceState: this.assetServiceState };
   }
 
-  set config({
-    chainId,
-    context,
-    assetServiceState,
-  }: {
-    chainId: ChainId;
-    context: ContextValue;
-    assetServiceState?: AssetServiceState;
-  }) {
+  set config({ chainId, context, assetServiceState }: Config) {
     this.chainId = chainId;
     this.context = new Context(context);
     this.assetServiceState = assetServiceState;


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

Add a config setter to be able to change configurations (chainId, context and assetServiceState) dynamically after initialisation. Usage:
```typescript
// Initialise a Yearn instance
const sdkInstance = new Yearn(1, {
  provider,
  zapper: ZAPPER_API_KEY,
  // ...
});
// then we can dynamically change the config by
sdkInstance.config = {
  chainId: 250,
  context: {
    anotherProvider,
    zapper: 'anotherZapperKey',
    // ...
  },
};
```

## Related Issue

<!--- Please link to the issue here -->

N/A

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Currently after initialisation it is not possible to change the configs in the context

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Ran locally with yalc