### PR TITLE
feat: fantom zaps support

### DIFF
--- a/src/chain.ts
+++ b/src/chain.ts
@@ -102,7 +102,7 @@ export const NETWORK_SETTINGS: NetworkSettings = {
       address: NATIVE_TOKEN_ADDRESS,
     },
     wrappedTokenAddress: "0x21be370D5312f44cB42ce377BC9b8a0cEF1A4C83",
-    simulationsEnabled: false,
+    simulationsEnabled: true,
     zapsEnabled: true,
     zapOutTokenSymbols: ["FTM", "DAI", "USDC", "USDT"],
     blockExplorerUrl: "https://ftmscan.com",

--- a/src/chain.ts
+++ b/src/chain.ts
@@ -1,3 +1,6 @@
+import { EthAddress, NativeTokenAddress } from "./helpers";
+import { Address } from "./types";
+
 /**
  * Supported chains in the yearn ecosystem.
  */
@@ -9,11 +12,7 @@ export const Chains = {
   42161: "arbitrum",
 };
 
-export type EthMain = 1;
-export type OpMain = 10;
-export type FtmMain = 250;
-export type EthLocal = 1337;
-export type ArbitrumOne = 42161;
+export type Network = "ethereum" | "optimism" | "fantom" | "arbitrum";
 
 export type ChainId = keyof typeof Chains;
 
@@ -34,3 +33,104 @@ export const isArbitrum = (chainId: ChainId): boolean => {
 };
 
 export const allSupportedChains = Object.keys(Chains).map((key) => Number(key));
+
+export interface NetworkSettings {
+  [chainId: number]: {
+    id: Network;
+    name: string;
+    chainId: number;
+    rpcUrl: string;
+    nativeCurrency: {
+      name: string;
+      symbol: string;
+      decimals: number;
+      address: Address;
+    };
+    wrappedTokenAddress?: Address;
+    simulationsEnabled?: boolean;
+    zapsEnabled?: boolean;
+    zapOutTokenSymbols?: string[];
+    blockExplorerUrl?: string;
+  };
+}
+
+export const NETWORK_SETTINGS: NetworkSettings = {
+  1: {
+    id: "ethereum",
+    name: "Ethereum",
+    chainId: 1,
+    rpcUrl: "https://mainnet.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161",
+    nativeCurrency: {
+      name: "Ethereum",
+      symbol: "ETH",
+      decimals: 18,
+      address: EthAddress,
+    },
+    wrappedTokenAddress: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+    simulationsEnabled: true,
+    zapsEnabled: true,
+    zapOutTokenSymbols: ["ETH", "DAI", "USDC", "USDT", "WBTC"],
+    blockExplorerUrl: "https://etherscan.io",
+  },
+  10: {
+    id: "optimism",
+    name: "Optimism",
+    chainId: 10,
+    rpcUrl: "https://mainnet.optimism.io",
+    nativeCurrency: {
+      name: "Ethereum",
+      symbol: "ETH",
+      decimals: 18,
+      address: NativeTokenAddress,
+    },
+    simulationsEnabled: false,
+    zapsEnabled: false,
+    blockExplorerUrl: "https://optimistic.etherscan.io",
+  },
+  250: {
+    id: "fantom",
+    name: "Fantom",
+    chainId: 250,
+    rpcUrl: "https://rpc.ftm.tools",
+    nativeCurrency: {
+      name: "Fantom",
+      symbol: "FTM",
+      decimals: 18,
+      address: NativeTokenAddress,
+    },
+    wrappedTokenAddress: "0x21be370D5312f44cB42ce377BC9b8a0cEF1A4C83",
+    simulationsEnabled: false,
+    zapsEnabled: true,
+    zapOutTokenSymbols: ["FTM", "DAI", "USDC", "USDT"],
+    blockExplorerUrl: "https://ftmscan.com",
+  },
+  1337: {
+    id: "ethereum",
+    name: "Ethereum",
+    chainId: 1337,
+    rpcUrl: "http://localhost:8545",
+    nativeCurrency: {
+      name: "Ethereum",
+      symbol: "ETH",
+      decimals: 18,
+      address: EthAddress,
+    },
+    simulationsEnabled: false,
+    zapsEnabled: true,
+  },
+  42161: {
+    id: "arbitrum",
+    name: "Arbitrum",
+    chainId: 42161,
+    rpcUrl: "https://arb1.arbitrum.io/rpc",
+    nativeCurrency: {
+      name: "Ethereum",
+      symbol: "ETH",
+      decimals: 18,
+      address: NativeTokenAddress,
+    },
+    simulationsEnabled: false,
+    zapsEnabled: false,
+    blockExplorerUrl: "https://arbiscan.io",
+  },
+};

--- a/src/chain.ts
+++ b/src/chain.ts
@@ -1,4 +1,3 @@
-import { EthAddress, NativeTokenAddress } from "./helpers";
 import { Address } from "./types";
 
 /**
@@ -34,6 +33,10 @@ export const isArbitrum = (chainId: ChainId): boolean => {
 
 export const allSupportedChains = Object.keys(Chains).map((key) => Number(key));
 
+const ETH_ADDRESS = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+const NATIVE_TOKEN_ADDRESS = ZERO_ADDRESS;
+
 export interface NetworkSettings {
   [chainId: number]: {
     id: Network;
@@ -44,7 +47,7 @@ export interface NetworkSettings {
       name: string;
       symbol: string;
       decimals: number;
-      address: Address;
+      address: string;
     };
     wrappedTokenAddress?: Address;
     simulationsEnabled?: boolean;
@@ -64,7 +67,7 @@ export const NETWORK_SETTINGS: NetworkSettings = {
       name: "Ethereum",
       symbol: "ETH",
       decimals: 18,
-      address: EthAddress,
+      address: ETH_ADDRESS,
     },
     wrappedTokenAddress: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
     simulationsEnabled: true,
@@ -81,7 +84,7 @@ export const NETWORK_SETTINGS: NetworkSettings = {
       name: "Ethereum",
       symbol: "ETH",
       decimals: 18,
-      address: NativeTokenAddress,
+      address: NATIVE_TOKEN_ADDRESS,
     },
     simulationsEnabled: false,
     zapsEnabled: false,
@@ -96,7 +99,7 @@ export const NETWORK_SETTINGS: NetworkSettings = {
       name: "Fantom",
       symbol: "FTM",
       decimals: 18,
-      address: NativeTokenAddress,
+      address: NATIVE_TOKEN_ADDRESS,
     },
     wrappedTokenAddress: "0x21be370D5312f44cB42ce377BC9b8a0cEF1A4C83",
     simulationsEnabled: false,
@@ -113,10 +116,12 @@ export const NETWORK_SETTINGS: NetworkSettings = {
       name: "Ethereum",
       symbol: "ETH",
       decimals: 18,
-      address: EthAddress,
+      address: ETH_ADDRESS,
     },
+    wrappedTokenAddress: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
     simulationsEnabled: false,
     zapsEnabled: true,
+    zapOutTokenSymbols: ["ETH", "DAI", "USDC", "USDT", "WBTC"],
   },
   42161: {
     id: "arbitrum",
@@ -127,7 +132,7 @@ export const NETWORK_SETTINGS: NetworkSettings = {
       name: "Ethereum",
       symbol: "ETH",
       decimals: 18,
-      address: NativeTokenAddress,
+      address: NATIVE_TOKEN_ADDRESS,
     },
     simulationsEnabled: false,
     zapsEnabled: false,

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,50 +1,23 @@
 import { BigNumber } from "@ethersproject/bignumber";
 
-import { Address, Integer, SdkError, Token, Usdc } from "./types";
+import { ChainId, NETWORK_SETTINGS } from "./chain";
+import { Address, Integer, SdkError, Usdc } from "./types";
 import { toBN } from "./utils";
 
 export const ZeroAddress = "0x0000000000000000000000000000000000000000";
 export const EthAddress = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
-export const NativeTokenAddress = ZeroAddress;
 export const WethAddress = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
-export const WrappedFantomAddress = "0x21be370D5312f44cB42ce377BC9b8a0cEF1A4C83";
-
-export const SUPPORTED_ZAP_OUT_ADDRESSES_MAINNET = {
-  ETH: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-  DAI: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
-  USDC: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
-  USDT: "0xdAC17F958D2ee523a2206206994597C13D831ec7",
-  WBTC: "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
-};
-
-export const FANTOM_TOKEN: Token = {
-  address: NativeTokenAddress,
-  name: "Fantom",
-  dataSource: "sdk",
-  decimals: "18",
-  priceUsdc: "0",
-  supported: {
-    ftmApeZap: true,
-  },
-  symbol: "FTM",
-};
-
-export const WETH_TOKEN: Token = {
-  address: WethAddress,
-  name: "WETH",
-  dataSource: "sdk",
-  decimals: "18",
-  priceUsdc: "0",
-  supported: {
-    zapper: true,
-    vaults: true,
-  },
-  symbol: "WETH",
-};
+export const NativeTokenAddress = ZeroAddress;
 
 // Returns truthy if address is defined as a native token address of a network
 export function isNativeToken(address: Address): boolean {
   return [EthAddress, NativeTokenAddress].includes(address);
+}
+
+// Returns wrapper token address if it exists and its the native token address of a network
+export function getWrapperIfNative(address: Address, chainId: ChainId): Address {
+  const networkSettings = NETWORK_SETTINGS[chainId];
+  return isNativeToken(address) ? networkSettings.wrappedTokenAddress ?? address : address;
 }
 
 // handle a non-200 `fetch` response.

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -5,6 +5,7 @@ import { toBN } from "./utils";
 
 export const ZeroAddress = "0x0000000000000000000000000000000000000000";
 export const EthAddress = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
+export const NativeTokenAddress = ZeroAddress;
 export const WethAddress = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
 export const WrappedFantomAddress = "0x21be370D5312f44cB42ce377BC9b8a0cEF1A4C83";
 
@@ -16,10 +17,8 @@ export const SUPPORTED_ZAP_OUT_ADDRESSES_MAINNET = {
   WBTC: "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
 };
 
-export const SUPPORTED_ZAP_OUT_TOKEN_SYMBOLS = ["ETH", "DAI", "USDC", "USDT", "WBTC"];
-
 export const FANTOM_TOKEN: Token = {
-  address: ZeroAddress,
+  address: NativeTokenAddress,
   name: "Fantom",
   dataSource: "sdk",
   decimals: "18",
@@ -28,18 +27,6 @@ export const FANTOM_TOKEN: Token = {
     ftmApeZap: true,
   },
   symbol: "FTM",
-};
-
-export const ETH_TOKEN: Token = {
-  address: EthAddress,
-  name: "ETH",
-  dataSource: "sdk",
-  decimals: "18",
-  priceUsdc: "0",
-  supported: {
-    zapper: true,
-  },
-  symbol: "ETH",
 };
 
 export const WETH_TOKEN: Token = {
@@ -57,7 +44,7 @@ export const WETH_TOKEN: Token = {
 
 // Returns truthy if address is defined as a native token address of a network
 export function isNativeToken(address: Address): boolean {
-  return [EthAddress, ZeroAddress].includes(address);
+  return [EthAddress, NativeTokenAddress].includes(address);
 }
 
 // handle a non-200 `fetch` response.

--- a/src/interfaces/helpers/mergeZapPropsWithAddressables.spec.ts
+++ b/src/interfaces/helpers/mergeZapPropsWithAddressables.spec.ts
@@ -1,4 +1,3 @@
-import { FANTOM_TOKEN } from "../../helpers";
 import { createMockTokenMarketData, createMockVaultMetadata } from "../../test-utils/factories";
 import { mergeZapPropsWithAddressables } from "./mergeZapPropsWithAddressables";
 
@@ -47,46 +46,6 @@ describe("mergeZapPropsWithAddressables", () => {
           allowZapOut: true,
           zapInWith: "zapperZapIn",
           zapOutWith: "zapperZapOut",
-        },
-        {
-          ...vaultMetadataMock.notZappable,
-          allowZapIn: false,
-          allowZapOut: false,
-          zapInWith: undefined,
-          zapOutWith: undefined,
-        },
-      ])
-    );
-  });
-
-  it("should set the ftmApeZap properties on an addressable", async () => {
-    const vaultMetadataMock = {
-      ftm: createMockVaultMetadata({
-        displayName: "Zappable",
-        address: FANTOM_TOKEN.address,
-      }),
-      notZappable: createMockVaultMetadata({
-        displayName: "Not Zappable",
-        address: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
-      }),
-    };
-
-    const actual = mergeZapPropsWithAddressables({
-      addressables: [vaultMetadataMock.ftm, vaultMetadataMock.notZappable],
-      supportedVaultAddresses: [FANTOM_TOKEN.address],
-      zapInType: "ftmApeZap",
-      zapOutType: "ftmApeZap",
-    });
-
-    expect(actual.length).toEqual(2);
-    expect(actual).toEqual(
-      expect.arrayContaining([
-        {
-          ...vaultMetadataMock.ftm,
-          allowZapIn: true,
-          allowZapOut: true,
-          zapInWith: "ftmApeZap",
-          zapOutWith: "ftmApeZap",
         },
         {
           ...vaultMetadataMock.notZappable,

--- a/src/interfaces/simulation.ts
+++ b/src/interfaces/simulation.ts
@@ -5,7 +5,7 @@ import BigNumber from "bignumber.js";
 
 import { ChainId } from "../chain";
 import { ServiceInterface } from "../common";
-import { EthAddress, isNativeToken, WethAddress, ZeroAddress } from "../helpers";
+import { getWrapperIfNative, isNativeToken } from "../helpers";
 import { PickleJars } from "../services/partners/pickle";
 import { SimulationExecutor, SimulationResponse } from "../simulationExecutor";
 import {
@@ -212,8 +212,7 @@ export class SimulationInterface<T extends ChainId> extends ServiceInterface<T> 
     account: Address,
     simulationOutcome: SimulationResponse
   ): Promise<TransactionOutcome> {
-    const sourceTokenAddress = token === EthAddress ? WethAddress : token;
-    const sourceToken = await this.yearn.tokens.findByAddress(sourceTokenAddress);
+    const sourceToken = await this.yearn.tokens.findByAddress(getWrapperIfNative(token, this.chainId));
     const [vaultData] = await this.yearn.vaults.get([vault]);
     const targetTokenAmount = await this.parseSimulationTargetTokenAmount(vault, account, simulationOutcome);
     const sourceTokenAmountUsdc = toBN(sourceToken?.priceUsdc)
@@ -379,7 +378,7 @@ export class SimulationInterface<T extends ChainId> extends ServiceInterface<T> 
     const targetTokenAmount = await this.parseSimulationTargetTokenAmount(token, account, simulationOutcome);
     const sourceTokenAmountUsdc = await this.yearn.services.oracle.getNormalizedValueUsdc(vault, amount);
     const targetTokenAmountUsdc = await this.yearn.services.oracle.getNormalizedValueUsdc(
-      token === EthAddress ? WethAddress : token,
+      getWrapperIfNative(token, this.chainId),
       targetTokenAmount
     );
     const conversionRate = toBN(sourceTokenAmountUsdc).eq(0)
@@ -530,8 +529,6 @@ export class SimulationInterface<T extends ChainId> extends ServiceInterface<T> 
     vault: ZappableVault;
     skipGasEstimate: boolean;
   }): Promise<TransactionOutcome> {
-    const zapToken = sellToken === EthAddress ? ZeroAddress : sellToken;
-
     if (!options.slippage) {
       throw new SdkError("slippage needs to be set", SdkError.NO_SLIPPAGE);
     }
@@ -539,7 +536,7 @@ export class SimulationInterface<T extends ChainId> extends ServiceInterface<T> 
     const partnerId = this.yearn.services.partner?.partnerId;
     const zapProtocol = this.getZapProtocol({ vaultAddress: toVault });
     const zapInParams = await this.yearn.services.portals
-      .zapIn(toVault, zapToken, amount, from, options.slippage, !skipGasEstimate, partnerId)
+      .zapIn(toVault, sellToken, amount, from, options.slippage, !skipGasEstimate, partnerId)
       .catch(() => {
         throw new ZapError("zap in", ZapError.ZAP_IN);
       });
@@ -605,11 +602,12 @@ export class SimulationInterface<T extends ChainId> extends ServiceInterface<T> 
         break;
     }
 
-    const oracleToken = sellToken === EthAddress ? WethAddress : sellToken;
     const zapInAmountUsdc = toBN(
-      await this.yearn.services.oracle.getNormalizedValueUsdc(oracleToken, amount).catch(() => {
-        throw new PriceFetchingError("error fetching price", PriceFetchingError.FETCHING_PRICE_ORACLE);
-      })
+      await this.yearn.services.oracle
+        .getNormalizedValueUsdc(getWrapperIfNative(sellToken, this.chainId), amount)
+        .catch(() => {
+          throw new PriceFetchingError("error fetching price", PriceFetchingError.FETCHING_PRICE_ORACLE);
+        })
     );
 
     const conversionRate = amountReceivedUsdc.div(zapInAmountUsdc).toNumber();
@@ -713,9 +711,8 @@ export class SimulationInterface<T extends ChainId> extends ServiceInterface<T> 
       throw new SdkError("slippage needs to be set", SdkError.NO_SLIPPAGE);
     }
 
-    const zapToken = toToken === EthAddress ? ZeroAddress : toToken;
     const zapOutParams = await this.yearn.services.portals
-      .zapOut(fromVault, zapToken, amount, from, options.slippage, skipGasEstimate)
+      .zapOut(fromVault, toToken, amount, from, options.slippage, skipGasEstimate)
       .catch(() => {
         throw new ZapError("error zapping out", ZapError.ZAP_OUT);
       });
@@ -727,7 +724,7 @@ export class SimulationInterface<T extends ChainId> extends ServiceInterface<T> 
     const tokensReceived = await (async (): Promise<string> => {
       if (!zapOutParams.from || !zapOutParams.to || !zapOutParams.data)
         throw new ZapError("error zapping out", ZapError.ZAP_OUT);
-      if (zapToken === ZeroAddress) {
+      if (isNativeToken(toToken)) {
         const response: SimulationResponse = await this.simulationExecutor.makeSimulationRequest(
           from,
           zapOutParams.to,
@@ -748,9 +745,8 @@ export class SimulationInterface<T extends ChainId> extends ServiceInterface<T> 
       }
     })();
 
-    const oracleToken = toToken === EthAddress ? WethAddress : toToken;
     const zapOutAmountUsdc = await this.yearn.services.oracle
-      .getNormalizedValueUsdc(oracleToken, tokensReceived)
+      .getNormalizedValueUsdc(getWrapperIfNative(toToken, this.chainId), tokensReceived)
       .catch(() => {
         throw new PriceFetchingError("error fetching price", PriceFetchingError.FETCHING_PRICE_ORACLE);
       });
@@ -784,7 +780,7 @@ export class SimulationInterface<T extends ChainId> extends ServiceInterface<T> 
     toVault,
     options,
   }: DepositArgs): Promise<{ needsApproving: boolean } & ApprovalData> {
-    if (sellToken === EthAddress) {
+    if (isNativeToken(sellToken)) {
       return { needsApproving: false };
     }
 

--- a/src/interfaces/token.spec.ts
+++ b/src/interfaces/token.spec.ts
@@ -5,7 +5,7 @@ import { Contract } from "@ethersproject/contracts";
 import { Address, ChainId, Integer, SdkError, Token, TokenInterface, TokenMetadata } from "..";
 import { CachedFetcher } from "../cache";
 import { Context } from "../context";
-import { EthAddress, SUPPORTED_ZAP_OUT_ADDRESSES_MAINNET, ZeroAddress } from "../helpers";
+import { EthAddress, ZeroAddress } from "../helpers";
 import {
   createMockBalance,
   createMockPopulatedTransaction,
@@ -438,7 +438,7 @@ describe("TokenInterface", () => {
             const supportedZapTokenWithIcon = createMockToken({ address: "0x003" });
             const supportedZapTokenWithoutIcon = createMockToken({ address: "0x004" });
             const supportedZapTokenWithZapOut = createMockToken({
-              address: SUPPORTED_ZAP_OUT_ADDRESSES_MAINNET.USDC,
+              symbol: "USDC",
             });
 
             zapSupportedTokensMock.mockResolvedValue([
@@ -539,7 +539,6 @@ describe("TokenInterface", () => {
 
       describe("when chainId is 250 (fantom)", () => {
         let vaultsToken: Token;
-        let fantomToken: Token;
 
         beforeEach(() => {
           tokenInterface = new TokenInterface(mockedYearn, 250, new Context({}));
@@ -548,26 +547,15 @@ describe("TokenInterface", () => {
             symbol: "VAULT",
             name: "Vault Token",
           });
-          fantomToken = {
-            address: ZeroAddress,
-            name: "Fantom",
-            dataSource: "sdk",
-            decimals: "18",
-            priceUsdc: "1000000", // $1
-            supported: {
-              ftmApeZap: true,
-            },
-            symbol: "FTM",
-          };
           vaultsTokensMock.mockResolvedValue([vaultsToken]);
         });
 
-        it("should fetch all the tokens only from Vaults (not Zap)", async () => {
+        it("should fetch all the tokens from Zap and Vaults", async () => {
           const actualSupportedTokens = await tokenInterface.supported();
 
-          expect(actualSupportedTokens.length).toEqual(2);
-          expect(actualSupportedTokens).toEqual(expect.arrayContaining([vaultsToken, fantomToken]));
-          expect(zapSupportedTokensMock).not.toHaveBeenCalled();
+          expect(actualSupportedTokens.length).toEqual(1);
+          expect(actualSupportedTokens).toEqual(expect.arrayContaining([vaultsToken]));
+          expect(zapSupportedTokensMock).toHaveBeenCalled();
           expect(assetReadyThenMock).not.toHaveBeenCalled();
           expect(vaultsTokensMock).toHaveBeenCalledTimes(1);
         });

--- a/src/interfaces/token.spec.ts
+++ b/src/interfaces/token.spec.ts
@@ -5,7 +5,7 @@ import { Contract } from "@ethersproject/contracts";
 import { Address, ChainId, Integer, SdkError, Token, TokenInterface, TokenMetadata } from "..";
 import { CachedFetcher } from "../cache";
 import { Context } from "../context";
-import { ETH_TOKEN, EthAddress, SUPPORTED_ZAP_OUT_ADDRESSES_MAINNET, ZeroAddress } from "../helpers";
+import { EthAddress, SUPPORTED_ZAP_OUT_ADDRESSES_MAINNET, ZeroAddress } from "../helpers";
 import {
   createMockBalance,
   createMockPopulatedTransaction,
@@ -232,8 +232,13 @@ describe("TokenInterface", () => {
               vaultTokenWithBalance,
               zapTokenWithBalance,
               {
-                address: EthAddress,
-                token: ETH_TOKEN,
+                address: "0xAccount",
+                token: {
+                  address: EthAddress,
+                  name: "Ethereum",
+                  decimals: "18",
+                  symbol: "ETH",
+                },
                 balance: "42000000000000000000",
                 balanceUsdc: "42000000",
                 priceUsdc: "1000000",
@@ -255,8 +260,13 @@ describe("TokenInterface", () => {
             expect.arrayContaining([
               vaultTokenWithBalance,
               {
-                address: EthAddress,
-                token: ETH_TOKEN,
+                address: "0xAccount",
+                token: {
+                  address: EthAddress,
+                  name: "Ethereum",
+                  decimals: "18",
+                  symbol: "ETH",
+                },
                 balance: "42000000000000000000",
                 balanceUsdc: "42000000",
                 priceUsdc: "1000000",
@@ -303,18 +313,15 @@ describe("TokenInterface", () => {
               balanceUsdc: "42000000", // $42
               priceUsdc: "1000000", // $1
               token: {
-                address: "0x0000000000000000000000000000000000000000",
-                dataSource: "sdk",
+                address: ZeroAddress,
                 decimals: "18",
                 name: "Fantom",
-                priceUsdc: "0",
-                supported: { ftmApeZap: true },
                 symbol: "FTM",
               },
             },
           ])
         );
-        expect(zapBalancesMock).not.toHaveBeenCalled();
+        expect(zapBalancesMock).toHaveBeenCalled();
         expect(vaultsBalancesMock).toHaveBeenCalledWith("0xAccount");
       });
 
@@ -333,18 +340,15 @@ describe("TokenInterface", () => {
               balanceUsdc: "42000000", // $42
               priceUsdc: "1000000", // $1
               token: {
-                address: "0x0000000000000000000000000000000000000000",
-                dataSource: "sdk",
+                address: ZeroAddress,
                 decimals: "18",
                 name: "Fantom",
-                priceUsdc: "0",
-                supported: { ftmApeZap: true },
                 symbol: "FTM",
               },
             },
           ])
         );
-        expect(zapBalancesMock).not.toHaveBeenCalled();
+        expect(zapBalancesMock).toHaveBeenCalled();
         expect(vaultsBalancesMock).toHaveBeenCalledWith("0xAccount");
       });
     });

--- a/src/interfaces/token.spec.ts
+++ b/src/interfaces/token.spec.ts
@@ -232,7 +232,7 @@ describe("TokenInterface", () => {
               vaultTokenWithBalance,
               zapTokenWithBalance,
               {
-                address: "0xAccount",
+                address: EthAddress,
                 token: {
                   address: EthAddress,
                   name: "Ethereum",
@@ -260,7 +260,7 @@ describe("TokenInterface", () => {
             expect.arrayContaining([
               vaultTokenWithBalance,
               {
-                address: "0xAccount",
+                address: EthAddress,
                 token: {
                   address: EthAddress,
                   name: "Ethereum",
@@ -308,7 +308,7 @@ describe("TokenInterface", () => {
           expect.arrayContaining([
             vaultTokenWithBalance,
             {
-              address: "0xAccount",
+              address: ZeroAddress,
               balance: "42000000000000000000", // 42 FTM
               balanceUsdc: "42000000", // $42
               priceUsdc: "1000000", // $1
@@ -335,7 +335,7 @@ describe("TokenInterface", () => {
           expect.arrayContaining([
             vaultTokenWithBalance,
             {
-              address: "0xAccount",
+              address: ZeroAddress,
               balance: "42000000000000000000", // 42 FTM
               balanceUsdc: "42000000", // $42
               priceUsdc: "1000000", // $1

--- a/src/interfaces/token.ts
+++ b/src/interfaces/token.ts
@@ -4,9 +4,9 @@ import { TransactionResponse } from "@ethersproject/providers";
 import BigNumber from "bignumber.js";
 
 import { CachedFetcher } from "../cache";
-import { allSupportedChains, ChainId, Chains, isEthereum, isFantom } from "../chain";
+import { allSupportedChains, ChainId, Chains, isEthereum, isFantom, NETWORK_SETTINGS } from "../chain";
 import { ServiceInterface } from "../common";
-import { ETH_TOKEN, EthAddress, isNativeToken } from "../helpers";
+import { isNativeToken } from "../helpers";
 import { FANTOM_TOKEN, mergeByAddress, SUPPORTED_ZAP_OUT_ADDRESSES_MAINNET, WrappedFantomAddress } from "../helpers";
 import {
   Address,
@@ -91,6 +91,7 @@ export class TokenInterface<C extends ChainId> extends ServiceInterface<C> {
    * @returns list of balances for the supported tokens
    */
   async balances(account: Address, tokenAddresses?: Address[]): Promise<Balance[]> {
+    const networkSettings = NETWORK_SETTINGS[this.chainId];
     let tokens = await this.supported();
 
     if (tokenAddresses) {
@@ -119,7 +120,7 @@ export class TokenInterface<C extends ChainId> extends ServiceInterface<C> {
       sdk: [],
     };
 
-    if (isEthereum(this.chainId)) {
+    if (networkSettings?.zapsEnabled) {
       try {
         const zapBalances = await this.yearn.services.portals.balances(account);
         balances.portals = zapBalances.filter(({ address }) => addresses.portals.has(address));
@@ -128,12 +129,18 @@ export class TokenInterface<C extends ChainId> extends ServiceInterface<C> {
       }
 
       try {
+        const { address, name, symbol, decimals } = networkSettings.nativeCurrency;
         const balance = await this.ctx.provider.read.getBalance(account);
-        const priceUsdc = await this.yearn.services.oracle.getPriceUsdc(EthAddress);
+        const priceUsdc = await this.yearn.services.oracle.getPriceUsdc(networkSettings.wrappedTokenAddress ?? address);
         balances.sdk = [
           {
-            address: EthAddress,
-            token: ETH_TOKEN,
+            address: account,
+            token: {
+              address,
+              name,
+              decimals: decimals.toString(),
+              symbol,
+            },
             balance: balance.toString(),
             balanceUsdc: new BigNumber(balance.toString())
               .div(10 ** 18)
@@ -145,23 +152,6 @@ export class TokenInterface<C extends ChainId> extends ServiceInterface<C> {
       } catch (error) {
         console.error(error);
       }
-    }
-
-    if (isFantom(this.chainId)) {
-      const balance = await this.ctx.provider.read.getBalance(account);
-      const priceUsdc = await this.yearn.services.oracle.getPriceUsdc(WrappedFantomAddress);
-      balances.sdk = [
-        {
-          address: account,
-          token: FANTOM_TOKEN,
-          balance: balance.toString(),
-          balanceUsdc: new BigNumber(balance.toString())
-            .div(10 ** 18)
-            .times(new BigNumber(priceUsdc))
-            .toString(),
-          priceUsdc,
-        },
-      ];
     }
 
     if (allSupportedChains.includes(this.chainId)) {

--- a/src/interfaces/token.ts
+++ b/src/interfaces/token.ts
@@ -134,7 +134,7 @@ export class TokenInterface<C extends ChainId> extends ServiceInterface<C> {
         const priceUsdc = await this.yearn.services.oracle.getPriceUsdc(getWrapperIfNative(address, this.chainId));
         balances.sdk = [
           {
-            address: account,
+            address,
             token: {
               address,
               name,

--- a/src/interfaces/vault.ts
+++ b/src/interfaces/vault.ts
@@ -5,9 +5,9 @@ import { CallOverrides, Contract, PopulatedTransaction } from "@ethersproject/co
 import { TransactionRequest, TransactionResponse } from "@ethersproject/providers";
 
 import { CachedFetcher } from "../cache";
-import { ChainId, isEthereum, isFantom } from "../chain";
+import { ChainId, NETWORK_SETTINGS } from "../chain";
 import { ContractAddressId, ServiceInterface } from "../common";
-import { chunkArray, EthAddress, FANTOM_TOKEN, isNativeToken, WethAddress } from "../helpers";
+import { chunkArray, EthAddress, isNativeToken, WethAddress } from "../helpers";
 import { PickleJars } from "../services/partners/pickle";
 import {
   Address,
@@ -154,23 +154,14 @@ export class VaultInterface<T extends ChainId> extends ServiceInterface<T> {
           return Promise.resolve([]);
         });
 
-    if (isEthereum(this.chainId)) {
+    const networkSettings = NETWORK_SETTINGS[this.chainId];
+    if (networkSettings?.zapsEnabled) {
       const vaultTokenMarketData = await this.yearn.services.portals.supportedVaultAddresses();
       metadataOverrides = mergeZapPropsWithAddressables({
         addressables: metadataOverrides,
         supportedVaultAddresses: vaultTokenMarketData,
         zapInType: "portalsZapIn",
         zapOutType: "portalsZapOut",
-      });
-    }
-
-    if (isFantom(this.chainId)) {
-      const ftmApeZappableVault = [FANTOM_TOKEN.address]; // hardcoded for now
-      metadataOverrides = mergeZapPropsWithAddressables({
-        addressables: metadataOverrides,
-        supportedVaultAddresses: ftmApeZappableVault,
-        zapInType: "ftmApeZap",
-        zapOutType: "ftmApeZap",
       });
     }
 

--- a/src/services/assets.ts
+++ b/src/services/assets.ts
@@ -1,6 +1,6 @@
 import fetch from "cross-fetch";
 
-import { ChainId } from "../chain";
+import { ChainId, isEthereum } from "../chain";
 import { Service } from "../common";
 import { Context } from "../context";
 import { handleHttpError, WethAddress } from "../helpers";
@@ -57,7 +57,7 @@ export class AssetService extends Service {
   }
 
   private async initialize(): Promise<void> {
-    if (this.chainId === 1 || this.chainId === 1337) {
+    if (isEthereum(this.chainId)) {
       const aliases: Alias[] = await fetch(YearnAliases)
         .then(handleHttpError)
         .then((res) => res.json())

--- a/src/simulationExecutor.spec.ts
+++ b/src/simulationExecutor.spec.ts
@@ -64,7 +64,7 @@ describe("Simulation executor", () => {
 
   beforeEach(() => {
     const mockedTelegramService = new MockedTelegramServiceClass();
-    simulationExecutor = new SimulationExecutor(mockedTelegramService, new Context({}));
+    simulationExecutor = new SimulationExecutor(mockedTelegramService, 1, new Context({}));
     jest.spyOn(console, "error").mockImplementation();
   });
 

--- a/src/simulationExecutor.ts
+++ b/src/simulationExecutor.ts
@@ -3,6 +3,7 @@ import { BytesLike } from "@ethersproject/bytes";
 import { JsonRpcProvider, JsonRpcSigner, TransactionRequest } from "@ethersproject/providers";
 import BigNumber from "bignumber.js";
 
+import { ChainId } from "./chain";
 import { Context } from "./context";
 import { TelegramService } from "./services/telegram";
 import { EthersError, SimulationError, SimulationOptions, TenderlyError } from "./types";
@@ -49,7 +50,7 @@ interface SimulationCallTrace {
  * 3. Simulate the zap in using the approval transaction as the root
  */
 export class SimulationExecutor {
-  constructor(private telegram: TelegramService, private ctx: Context) {}
+  constructor(private telegram: TelegramService, private chainId: ChainId, private ctx: Context) {}
 
   /**
    * Simulate a transaction
@@ -146,7 +147,7 @@ export class SimulationExecutor {
       from,
       to,
       input: data,
-      network_id: transactionRequest.chainId?.toString() || "1",
+      network_id: this.chainId.toString(),
       block_number: latestBlockKey,
       simulation_type: "quick",
       root: options?.root,
@@ -238,7 +239,7 @@ export class SimulationExecutor {
     const body = {
       alias: "",
       description: "",
-      network_id: "1",
+      network_id: this.chainId.toString(),
     };
 
     const response: Response = await await fetch(`${baseUrl}/fork`, {

--- a/src/zap.ts
+++ b/src/zap.ts
@@ -1,4 +1,4 @@
-import { ChainId, isEthereum, isFantom } from "./chain";
+import { ChainId, NETWORK_SETTINGS } from "./chain";
 import { Token, ZappableVault } from "./types";
 
 export type ZapInWith = keyof Token["supported"];
@@ -26,20 +26,14 @@ export function getZapInDetails({ chainId, token, vault }: ZapInArgs): ZapInDeta
     return { isZapInSupported: false, zapInWith: null };
   }
 
-  if (isEthereum(chainId)) {
+  const networkSettings = NETWORK_SETTINGS[chainId];
+  if (networkSettings?.zapsEnabled) {
     const { zapInWith } = vault.metadata;
 
     if (zapInWith && isValidZap(zapInWith, token.supported)) {
       const isZapInSupported = Boolean(token.supported[zapInWith]);
       return { isZapInSupported, zapInWith: isZapInSupported ? zapInWith : null };
     }
-  }
-
-  if (isFantom(chainId)) {
-    const zapInWith = "ftmApeZap"; // Hardcoded for now
-
-    const isZapInSupported = Boolean(token.supported[zapInWith]);
-    return { isZapInSupported, zapInWith: isZapInSupported ? zapInWith : null };
   }
 
   return { isZapInSupported: false, zapInWith: null };
@@ -50,20 +44,14 @@ export function getZapOutDetails({ chainId, token, vault }: ZapOutArgs): ZapOutD
     return { isZapOutSupported: false, zapOutWith: null };
   }
 
-  if (isEthereum(chainId)) {
+  const networkSettings = NETWORK_SETTINGS[chainId];
+  if (networkSettings?.zapsEnabled) {
     const { zapOutWith } = vault.metadata;
 
     if (zapOutWith && isValidZap(zapOutWith, token.supported)) {
       const isZapOutSupported = Boolean(token.supported[zapOutWith]);
       return { isZapOutSupported, zapOutWith: isZapOutSupported ? zapOutWith : null };
     }
-  }
-
-  if (isFantom(chainId)) {
-    const zapOutWith = "ftmApeZap"; // Hardcoded for now
-
-    const isZapOutSupported = Boolean(token.supported[zapOutWith]);
-    return { isZapOutSupported, zapOutWith: isZapOutSupported ? zapOutWith : null };
   }
 
   return { isZapOutSupported: false, zapOutWith: null };


### PR DESCRIPTION
## Description

- Add support to zap into/from vaults on Fantom network

## Motivation and Context

- Users have the ability to use any of their tokens to deposit/withdraw into/from any vault on Fantom network, now that we are using a service provider that supports this network.

## How Has This Been Tested?

Tested locally loaded with web app.
