### PR TITLE
feat: enable zaps on Optimism 

### DIFF
--- a/src/chain.ts
+++ b/src/chain.ts
@@ -86,8 +86,10 @@ export const NETWORK_SETTINGS: NetworkSettings = {
       decimals: 18,
       address: NATIVE_TOKEN_ADDRESS,
     },
-    simulationsEnabled: false,
-    zapsEnabled: false,
+    wrappedTokenAddress: "0x4200000000000000000000000000000000000006",
+    simulationsEnabled: true,
+    zapsEnabled: true,
+    zapOutTokenSymbols: ["ETH", "DAI", "USDC", "USDT", "WBTC"],
     blockExplorerUrl: "https://optimistic.etherscan.io",
   },
   250: {

--- a/src/simulationExecutor.spec.ts
+++ b/src/simulationExecutor.spec.ts
@@ -4,7 +4,7 @@ import { JsonRpcSigner } from "@ethersproject/providers";
 import { TelegramService } from ".";
 import { Context } from "./context";
 import { SimulationExecutor } from "./simulationExecutor";
-import { EthersError, SimulationError, TenderlyError } from "./types";
+import { SimulationError, TenderlyError } from "./types";
 
 global.fetch = jest.fn(() =>
   Promise.resolve({
@@ -21,8 +21,6 @@ global.fetch = jest.fn(() =>
   })
 ) as jest.Mock;
 
-const populateTransactionMock = jest.fn().mockReturnValue(Promise.resolve(true));
-
 jest.mock("@ethersproject/providers");
 jest.mock("@ethersproject/contracts");
 
@@ -37,7 +35,6 @@ const buildSignerMock = (balance = 1, transactionCount = 1): any => {
   signer.getBalance = getBalanceMock;
   signer.getTransactionCount = getTransactionCountMock;
   signer.getSigner = (): any => signer;
-  signer.populateTransaction = populateTransactionMock;
   return signer;
 };
 
@@ -122,17 +119,6 @@ describe("Simulation executor", () => {
   });
 
   describe("makeSimulationRequest", () => {
-    it("should fail with EthersError populating transaction", async () => {
-      expect.assertions(2);
-      populateTransactionMock.mockReturnValueOnce(Promise.reject(new Error("something bad happened")));
-      try {
-        await simulationExecutor.makeSimulationRequest("0x000", "0x000", "1", {});
-      } catch (error) {
-        expect(error).toBeInstanceOf(EthersError);
-        expect(error).toHaveProperty("error_code", EthersError.POPULATING_TRANSACTION);
-      }
-    });
-
     it("should fail with TenderlyError simulation call", async () => {
       expect.assertions(2);
       (global.fetch as jest.Mock).mockReturnValueOnce(Promise.reject(new Error("something bad happened")));


### PR DESCRIPTION
## Description

- Enable zaps support on Optimism network

## Motivation and Context

- Allow users to directly zap _any_ token into/from yearn vaults on Optimism network for better UX.