### PR TITLE
feat: enable zaps on Arbitrum

### DIFF
--- a/src/chain.ts
+++ b/src/chain.ts
@@ -136,8 +136,10 @@ export const NETWORK_SETTINGS: NetworkSettings = {
       decimals: 18,
       address: NATIVE_TOKEN_ADDRESS,
     },
-    simulationsEnabled: false,
-    zapsEnabled: false,
+    wrappedTokenAddress: "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+    simulationsEnabled: true,
+    zapsEnabled: true,
+    zapOutTokenSymbols: ["ETH", "DAI", "USDC", "USDT", "WBTC"],
     blockExplorerUrl: "https://arbiscan.io",
   },
 };

--- a/src/interfaces/token.spec.ts
+++ b/src/interfaces/token.spec.ts
@@ -364,9 +364,9 @@ describe("TokenInterface", () => {
 
         const actualBalances = await tokenInterface.balances("0xAccount");
 
-        expect(actualBalances.length).toEqual(1);
+        expect(actualBalances.length).toEqual(2);
         expect(actualBalances).toEqual(expect.arrayContaining([vaultTokenWithBalance]));
-        expect(zapBalancesMock).not.toHaveBeenCalled();
+        expect(zapBalancesMock).toHaveBeenCalled();
         expect(vaultsBalancesMock).toHaveBeenCalledWith("0xAccount");
       });
 
@@ -375,9 +375,9 @@ describe("TokenInterface", () => {
 
         const actualBalances = await tokenInterface.balances("0xAccount", [vaultToken.address]);
 
-        expect(actualBalances.length).toEqual(1);
+        expect(actualBalances.length).toEqual(2);
         expect(actualBalances).toEqual(expect.arrayContaining([vaultTokenWithBalance]));
-        expect(zapBalancesMock).not.toHaveBeenCalled();
+        expect(zapBalancesMock).toHaveBeenCalled();
         expect(vaultsBalancesMock).toHaveBeenCalledWith("0xAccount");
       });
     });
@@ -574,12 +574,12 @@ describe("TokenInterface", () => {
           vaultsTokensMock.mockResolvedValue([vaultsToken]);
         });
 
-        it("should fetch all the tokens only from Vaults (not Zapper)", async () => {
+        it("should fetch all the tokens from Vaults and zaps", async () => {
           const actualSupportedTokens = await tokenInterface.supported();
 
           expect(actualSupportedTokens.length).toEqual(1);
           expect(actualSupportedTokens).toEqual(expect.arrayContaining([vaultsToken]));
-          expect(zapSupportedTokensMock).not.toHaveBeenCalled();
+          expect(zapSupportedTokensMock).toHaveBeenCalled();
           expect(assetReadyThenMock).not.toHaveBeenCalled();
           expect(vaultsTokensMock).toHaveBeenCalledTimes(1);
         });


### PR DESCRIPTION
## Description

- Enable zaps support on Arbitrum network

## Motivation and Context

- Allow users to directly zap _any_ token into/from yearn vaults on Arbitrum network for better UX.