### PR TITLE
feat: add protocol tokens support

### DIFF
--- a/src/services/portals.ts
+++ b/src/services/portals.ts
@@ -17,9 +17,11 @@ export class PortalsService extends Service {
     const endpoint = `${API}/v1/tokens/${network}`;
     const params = new URLSearchParams();
     const platforms = [...DEFAULT_PLATFORMS];
+    platforms.push("yearn");
     platforms.push("curve");
     platforms.push("beefy");
     if (isEthereum(this.chainId)) platforms.push("convex");
+    if (isEthereum(this.chainId)) platforms.push("compound");
     platforms.forEach((platform) => params.append("platforms[]", platform));
     const { tokens } = await fetch(`${endpoint}?${params}`)
       .then(handleHttpError)

--- a/src/services/portals.ts
+++ b/src/services/portals.ts
@@ -1,7 +1,7 @@
 import { getAddress } from "@ethersproject/address";
 import { TransactionRequest } from "@ethersproject/providers";
 
-import { Chains, isEthereum, isOptimism, NETWORK_SETTINGS } from "../chain";
+import { Chains, isEthereum, NETWORK_SETTINGS } from "../chain";
 import { Service } from "../common";
 import { EthAddress, handleHttpError, usdc, ZeroAddress } from "../helpers";
 import { Address, Balance, Integer, Token, TokenAllowance } from "../types";
@@ -17,7 +17,9 @@ export class PortalsService extends Service {
     const endpoint = `${API}/v1/tokens/${network}`;
     const params = new URLSearchParams();
     const platforms = [...DEFAULT_PLATFORMS];
-    if (isOptimism(this.chainId)) platforms.push("beefy");
+    platforms.push("curve");
+    platforms.push("beefy");
+    if (isEthereum(this.chainId)) platforms.push("convex");
     platforms.forEach((platform) => params.append("platforms[]", platform));
     const { tokens } = await fetch(`${endpoint}?${params}`)
       .then(handleHttpError)


### PR DESCRIPTION
## Description

- Add support to zap with Yearn, Curve, Beefy, Convex, and Compound protocol tokens on their supported networks.

## Motivation and Context

- Allow users to deposit with a wider variety of tokens to yearn vaults.